### PR TITLE
Validation fix

### DIFF
--- a/src/NeuralNets.jl
+++ b/src/NeuralNets.jl
@@ -6,6 +6,17 @@ using ArrayViews
 import Optim:levenberg_marquardt
 import Base: show
 
+# Not importing these results in warnings
+import Base:.*
+import Base:*
+import Base:/
+import Base:^
+import Base:-
+import Base:.-
+import Base:+
+import Base:.+
+import Base:setindex!
+
 
 # functions
 export train, gdmtrain, adatrain, prop

--- a/src/activations.jl
+++ b/src/activations.jl
@@ -14,13 +14,13 @@ identd(x) = 1
 tanhd(x) = sech(x).^2
 
 # dictionary of commonly-used activation derivatives
-derivs = Dict{Function, Function}([
-                                   logis     => logisd, 
+derivs = Dict{Function, Function}(
+                                   logis     => logisd,
                                    logissafe => logissafed,
-                                   relu      => relud, 
-                                   ident     => identd, 
+                                   relu      => relud,
+                                   ident     => identd,
                                    tanh      => tanhd
-                                   ])
+                                   )
 
 # automatic differentiateion with ForwardDiff.jl
 # due to limitations of ForwardDiff.jl, this function

--- a/src/train.jl
+++ b/src/train.jl
@@ -19,7 +19,7 @@ function diagnostic_trace!(h::TrainReport,
         push!(h.valid_error, valid_error)
     end
     if show_trace
-        if valid
+        if !valid
             print("training error: $train_error\r")
         else
             print("training error: $train_error, validation error: $valid_error\r")


### PR DESCRIPTION
# Fixed a few issues:

## Removed Depreciated Calls

The repository had some depreciated calls: `Dict([x => y])` rather than `Dict(x => y)` and `nothing` rather than `Void`.

## Addressed Julia Warnings

Every time I loaded the package I got an error that the following operator should be explicitly imported from base:

- `.*`
- `*`
- `/`
- `.-`
- `-`
- `.+`
- `+`
- `setindex!`

so I explicitly imported them.

## Fixed logging issue

The `diagnostic_trace!` function was only printing validation error when `valid` was false. I changed it to print validation error when `valid` was true.

# Added validation set functionality

## Added validation set to adatrain

Handled validation sets in `adatrain` the same way they were already handled in `gdmtrain`.

## Added check for convergence with validation set

If the validation set is present `e_valid_old` and `e_valid` are updated each iteration and used to check for convergence.
